### PR TITLE
Prompt for CLI parameters in VSCode extension

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,22 @@
+# Zumito CLI VSCode Extension
+
+This extension exposes basic Zumito CLI commands inside VS Code.
+
+## Features
+- `Zumito: Create Project` – run the CLI to scaffold a new project.
+- `Zumito: Create Module` – generate a module using the CLI.
+
+Each command opens a terminal and executes the corresponding CLI command so you can continue interacting with it.
+
+When you run `Zumito: Create Project`, the extension prompts for the project name, Discord credentials and other configuration values before invoking the CLI. `Zumito: Create Module` asks for the module name and type.
+
+## Building the VSIX
+
+Install dependencies and run the package script:
+
+```bash
+npm install
+npm run package
+```
+
+This generates a `zumito-extension-0.0.1.vsix` file in the extension folder.

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -1,0 +1,59 @@
+const vscode = require('vscode');
+const path = require('path');
+
+function runCLI(args) {
+    const cliPath = path.join(__dirname, '..', 'bin', 'index.js');
+    const command = `node ${cliPath} ${args}`;
+    const terminal = vscode.window.createTerminal('Zumito CLI');
+    terminal.sendText(command);
+    terminal.show();
+}
+
+function activate(context) {
+    const createProject = vscode.commands.registerCommand('zumito-cli.createProject', async () => {
+        const name = await vscode.window.showInputBox({ prompt: 'Project name' });
+        if (!name) { return; }
+
+        const discordToken = await vscode.window.showInputBox({ prompt: 'Discord bot token' });
+        if (!discordToken) { return; }
+
+        const discordClientId = await vscode.window.showInputBox({ prompt: 'Discord client ID' });
+        if (!discordClientId) { return; }
+
+        const discordClientSecret = await vscode.window.showInputBox({ prompt: 'Discord client secret' });
+        if (!discordClientSecret) { return; }
+
+        const botPrefix = await vscode.window.showInputBox({ prompt: 'Default prefix', value: 'zt-' });
+        if (!botPrefix) { return; }
+
+        const databaseType = await vscode.window.showQuickPick([
+            'sqlite', 'mysql', 'postgres', 'mongodb', 'tingodb', 'couchdb'
+        ], { placeHolder: 'Database type' });
+        if (!databaseType) { return; }
+
+        runCLI(
+            `create project --projectName "${name}" ` +
+            `--discordToken "${discordToken}" ` +
+            `--discordClientId "${discordClientId}" ` +
+            `--discordClientSecret "${discordClientSecret}" ` +
+            `--botPrefix "${botPrefix}" ` +
+            `--databaseType "${databaseType}"`
+        );
+    });
+
+    const createModule = vscode.commands.registerCommand('zumito-cli.createModule', async () => {
+        const moduleName = await vscode.window.showInputBox({ prompt: 'Module name' });
+        if (!moduleName) { return; }
+
+        const moduleType = await vscode.window.showQuickPick(['common', 'custom_behavior'], { placeHolder: 'Module type' });
+        if (!moduleType) { return; }
+
+        runCLI(`create module --name "${moduleName}" --type "${moduleType}"`);
+    });
+
+    context.subscriptions.push(createProject, createModule);
+}
+
+function deactivate() {}
+
+module.exports = { activate, deactivate };

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "zumito-extension",
+  "displayName": "Zumito CLI Extension",
+  "description": "VSCode extension to use Zumito CLI utilities within the editor.",
+  "version": "0.0.1",
+  "publisher": "zumito",
+  "engines": {
+    "vscode": "^1.70.0"
+  },
+  "main": "./extension.js",
+  "activationEvents": [
+    "onCommand:zumito-cli.createProject",
+    "onCommand:zumito-cli.createModule"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "zumito-cli.createProject",
+        "title": "Zumito: Create Project"
+      },
+      {
+        "command": "zumito-cli.createModule",
+        "title": "Zumito: Create Module"
+      }
+    ]
+  },
+  "scripts": {
+    "package": "vsce package"
+  },
+  "devDependencies": {
+    "vsce": "^2.15.0"
+  },
+  "dependencies": {}
+}


### PR DESCRIPTION
## Summary
- prompt for required project and module parameters in the VSCode extension
- document new prompts in the extension README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685011007fc0832fb7c95551800f25c9